### PR TITLE
Dockerfiles fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
 FROM node:14-alpine
+
 RUN apk add --no-cache build-base git python
-RUN npm install --global pm2
-WORKDIR /usr/app
+
+RUN mkdir -p /home/app && chown node:node /home/app
+USER node
+
+WORKDIR /home/app
+COPY --chown=node:node package*.json ./
 RUN npm install
-COPY . ./
+COPY --chown=node:node . ./
+
 EXPOSE 11375/tcp
+
 CMD ["npm", "run", "start"]


### PR DESCRIPTION
- Run as a normal user and not root
- Do `npm install` after adding `package.json` and `package-lock.json`
  files to the container
- Techincally, `npm install --global pm2` isn't used