### PR TITLE
feat: add new api to get on-chain stats for dev activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,22 @@ Accept: application/json
 
 ```
 
+## Query
+
+Counts the number of deployment transactions,
+and unique addresses making them within a specified date range.
+
+```
+GET /api/v1/rsk-activity-report/developer-activity?startDate=2022.04.01&endDate=2022.05.01&chain=rsk_testnet
+Accept: application/json
+
+```
+
 Query Parameters:
 
-- `days`: Number of days
+- `startDate`: Get stats from and including this date
+- `endDate`: Get stats up to and including this date
+- `chain`: Possible values are `rsk_mainnet` and `rsk_testnet`
 
 ## Author
 

--- a/api-router.js
+++ b/api-router.js
@@ -117,16 +117,16 @@ router.get('/rsk-address-report/protocol-usage', async (req, res) => {
 
 router.get('/rsk-activity-report/all-activity', async (req, res) => {
   try {
-    const { days } = req.query;
+    const { days, chain } = req.query;
     const allActivityReport = await rskActivityReport
-      .queryAllActivity(days);
+      .queryAllActivity(days, chain);
     res.status(200).json({
-      endPointVersion: 1,
+      endPointVersion: 2,
       ...allActivityReport
     });
   } catch (error) {
     res.status(400).json({
-      endPointVersion: 1,
+      endPointVersion: 2,
       error: error.message,
     });
   }
@@ -138,12 +138,12 @@ router.get('/rsk-activity-report/developer-activity', async (req, res) => {
     const allActivityReport = await rskActivityReport
       .queryDeveloperActivity(startDate, endDate, chain);
     res.status(200).json({
-      endPointVersion: 1,
+      endPointVersion: 2,
       ...allActivityReport
     });
   } catch (error) {
     res.status(400).json({
-      endPointVersion: 1,
+      endPointVersion: 2,
       error: error.message,
     });
   }

--- a/api-router.js
+++ b/api-router.js
@@ -118,7 +118,25 @@ router.get('/rsk-address-report/protocol-usage', async (req, res) => {
 router.get('/rsk-activity-report/all-activity', async (req, res) => {
   try {
     const { days } = req.query;
-    const allActivityReport = await rskActivityReport.queryAllActivity(days);
+    const allActivityReport = await rskActivityReport
+      .queryAllActivity(days);
+    res.status(200).json({
+      endPointVersion: 1,
+      ...allActivityReport
+    });
+  } catch (error) {
+    res.status(400).json({
+      endPointVersion: 1,
+      error: error.message,
+    });
+  }
+});
+
+router.get('/rsk-activity-report/developer-activity', async (req, res) => {
+  try {
+    const { startDate, endDate, chain } = req.query;
+    const allActivityReport = await rskActivityReport
+      .queryDeveloperActivity(startDate, endDate, chain);
     res.status(200).json({
       endPointVersion: 1,
       ...allActivityReport

--- a/util/activity-report.js
+++ b/util/activity-report.js
@@ -2,11 +2,6 @@ const db = require('../dbPool.js');
 const format = require('pg-format');
 const tokens = require('../data/tokens.json');
 
-function validateParams(days) {
-  if (isNaN(days) || days <= 0)
-    throw new Error(`Number of days '${days}' has unsupported format`);
-}
-
 async function getQueryResult(query) {
   const queryResult = await db.query(query);
   if (queryResult.rowCount === 0) return 0;
@@ -27,14 +22,71 @@ async function dbQueryAllActivity(days = 30) {
   return getQueryResult(query);
 }
 
+async function dbQueryDeveloperActivity(startDate, endDate, chainTableName) {
+  const queryStr = `
+  SELECT
+    COUNT(*) as deployment_tx_count,
+    COUNT(DISTINCT t.from) as deployment_account_count
+  FROM ${chainTableName}.block_transactions t
+  WHERE t.signed_at >= %L
+  AND t.signed_at <= %L
+  AND t.to IS NULL
+  `;
+  const query = format(
+    queryStr,
+    startDate,
+    endDate,
+  );
+  const queryResult = await db.query(query);
+  if (queryResult.rowCount === 0) {
+    return {
+      deployment_tx_count: 0,
+      deployment_account_count: 0,
+    };
+  }
+  return {
+    deployment_tx_count:
+      parseInt(queryResult.rows[0].deployment_tx_count),
+    deployment_account_count:
+      parseInt(queryResult.rows[0].deployment_account_count),
+  };
+}
+
 async function queryAllActivity(days) {
-  validateParams(days);
+  if (isNaN(days) || days <= 0)
+    throw new Error(`Number of days '${days}' has unsupported format`);
   const dbResult = await dbQueryAllActivity(days);
   return {
     accounts: dbResult,
   };
 }
 
+const chainTableNames = {
+  'rsk_testnet': 'chain_rsk_testnet',
+  'rsk_mainnet': 'chain_rsk_mainnet',
+};
+
+async function queryDeveloperActivity(
+  startDate,
+  endDate,
+  chain = 'rsk_testnet',
+) {
+  console.log(startDate, endDate, chain);
+  if (!startDate) {
+    throw new Error(`startDate '${startDate}' has unsupported format`);
+  }
+  if (!endDate) {
+    throw new Error(`endDate '${endDate}' has unsupported format`);
+  }
+  if (!chain || !chainTableNames[chain]) {
+    throw new Error(`chain '${chain}' is not supported`);
+  }
+  const queryResult = await dbQueryDeveloperActivity(
+    startDate, endDate, chainTableNames[chain]);
+  return queryResult;
+}
+
 module.exports = {
   queryAllActivity,
+  queryDeveloperActivity,
 };


### PR DESCRIPTION
## What

- add new API for developer activity
  - e.g. `/api/v1/rsk-activity-report/developer-activity?startDate=2022.04.01&endDate=2022.05.01`

## Why

- to obtain proxy metrics
