### PR TITLE
refactor: redirect all base url requests to devportal

### DIFF
--- a/server.js
+++ b/server.js
@@ -27,6 +27,12 @@ server.use(cors(corsOptions));
 if (process.env.NODE_ENV != 'production') {
   server.use(morgan('dev'));
 }
+
+// redirect all requests for https://self-service.rsk.co/
+server.all('/', (req, res) => {
+  res.status(302).redirect('https://developers.rsk.co/');
+});
+
 server.get('/api/status', (req, res) => {
   res.send({
     ok: Date.now(),


### PR DESCRIPTION
## What
redirect all `https://self-service.rsk.co/` requests to `https://developers.rsk.co/`

## Why
[DevEx Kanban ticket](https://www.notion.so/iovlabs/9f73ce020c4941e7a3f837fb4ac7a746?v=c421d3ea5aed4f5ebe99a919cac93510&p=4cd6589ea84e4438834f0b3c4ebef7e4&pm=s)