### PR TITLE
feat: update cors rules

### DIFF
--- a/server.js
+++ b/server.js
@@ -26,6 +26,9 @@ if (permissiveCors) {
       /\.rootstock\.io$/,
       'https://rifos.org',
       /\.rifos\.org$/,
+      // temporary ones below, currently used in staging environments
+      'https://gatsby-rsk-git-feature-stats-api-zgraya.vercel.app',
+      'https://gatsby-rsk-git-wp-zgraya.vercel.app',
     ],
     optionsSuccessStatus: 200,
   };

--- a/server.js
+++ b/server.js
@@ -19,7 +19,14 @@ if (permissiveCors) {
   };
 } else {
   corsOptions = {
-    origin: ['https://rsk.co', /\.rsk\.co$/],
+    origin: [
+      'https://rsk.co',
+      /\.rsk\.co$/,
+      'https://rootstock.io',
+      /\.rootstock\.io$/,
+      'https://rifos.org',
+      /\.rifos\.org$/,
+    ],
     optionsSuccessStatus: 200,
   };
 }


### PR DESCRIPTION
## What

- CORS whitelist add rootstock.io and rifos.org and their subdomains
- CORS whitelist of temporary domains used in staging environments

## Why

- These APIs are being invoked from these domains
